### PR TITLE
Metadata propagation, routingKey template

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ pipelines:
           # The routing key to use when publishing to an exchange
           # Type: string
           # Required: no
-          routingKey: ""
+          routingKey: "{{ index .Metadata "rabbitmq.routingKey" }}"
           # The path to the CA certificate to use for TLS
           # Type: string
           # Required: no

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -16,6 +16,7 @@ package rabbitmq
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +39,9 @@ func TestAcceptance(t *testing.T) {
 				queueName := setupQueueName(t, is)
 				sourceCfg["queue.name"] = queueName
 				destCfg["queue.name"] = queueName
+				destCfg["exchange.name"] = queueName
+				destCfg["exchange.type"] = "direct"
+				destCfg["routingKey"] = strings.ReplaceAll(t.Name(), "/", ".")
 			},
 			WriteTimeout: 500 * time.Millisecond,
 			ReadTimeout:  500 * time.Millisecond,
@@ -61,6 +65,8 @@ func TestAcceptance_TLS(t *testing.T) {
 	destCfg := config.Config{
 		"url":            testURLTLS,
 		"queue.name":     "random-queue",
+		"exchange.name":  "random-exchange",
+		"exchange.type":  "direct",
 		"tls.enabled":    "true",
 		"tls.clientCert": "./test/certs/client.cert.pem",
 		"tls.clientKey":  "./test/certs/client.key.pem",
@@ -84,7 +90,7 @@ func TestAcceptance_TLS(t *testing.T) {
 				queueName := setupQueueNameTLS(t, is, tlsConfig)
 				sourceCfg["queue.name"] = queueName
 				destCfg["queue.name"] = queueName
-				destCfg["routingKey"] = queueName
+				destCfg["routingKey"] = strings.ReplaceAll(t.Name(), "/", ".")
 			},
 			WriteTimeout: 500 * time.Millisecond,
 			ReadTimeout:  500 * time.Millisecond,

--- a/connector.yaml
+++ b/connector.yaml
@@ -279,7 +279,7 @@ specification:
       - name: routingKey
         description: The routing key to use when publishing to an exchange
         type: string
-        default: ""
+        default: '{{ index .Metadata "rabbitmq.routingKey" }}'
         validations: []
       - name: tls.caCert
         description: The path to the CA certificate to use for TLS

--- a/destination.go
+++ b/destination.go
@@ -109,6 +109,7 @@ func (d *Destination) Write(ctx context.Context, records []opencdc.Record) (int,
 			Type:      d.config.Delivery.MessageTypeName,
 			UserId:    d.config.Delivery.UserID,
 			AppId:     d.config.Delivery.AppID,
+			Headers:   metadataToHeaders(record.Metadata),
 			Body:      record.Bytes(),
 
 			Expiration: d.config.Delivery.Expiration,

--- a/destination_test.go
+++ b/destination_test.go
@@ -24,9 +24,10 @@ import (
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/matryer/is"
+	"github.com/rabbitmq/amqp091-go"
 )
 
-func generate3Records(queueName string) []opencdc.Record {
+func generate3Records(queueName, routingKey string) []opencdc.Record {
 	var recs []opencdc.Record
 
 	for i := range 3 {
@@ -38,7 +39,8 @@ func generate3Records(queueName string) []opencdc.Record {
 		rec := sdk.Util.Source.NewRecordCreate(
 			position,
 			opencdc.Metadata{
-				"rabbitmq.queue": queueName,
+				"rabbitmq.queue":                            queueName,
+				MetadataRabbitmqRoutingKey:                  routingKey,
 				MetadataRabbitmqHeaderPrefix + "queue_name": queueName,
 			},
 			opencdc.StructuredData{"id": i},
@@ -51,12 +53,17 @@ func generate3Records(queueName string) []opencdc.Record {
 	return recs
 }
 
-func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey string) {
+func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey, routingKeyTemplate string) {
 	ctx := context.Background()
 
 	sourceCfg := map[string]string{
 		"url":        testURL,
 		"queue.name": queueName,
+	}
+
+	routingKeyCfg := routingKey
+	if routingKeyTemplate != "" {
+		routingKeyCfg = routingKeyTemplate
 	}
 
 	destCfg := map[string]string{
@@ -65,7 +72,7 @@ func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey st
 		"delivery.contentType": "text/plain",
 		"exchange.name":        exchangeName,
 		"exchange.type":        exchangeType,
-		"routingKey":           routingKey,
+		"routingKey":           routingKeyCfg,
 	}
 
 	dest := NewDestination()
@@ -76,7 +83,7 @@ func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey st
 	is.NoErr(err)
 	defer teardownResource(ctx, is, dest)
 
-	recs := generate3Records(queueName)
+	recs := generate3Records(queueName, routingKey)
 	_, err = dest.Write(ctx, recs)
 	is.NoErr(err)
 
@@ -92,6 +99,7 @@ func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey st
 		readRec, err := src.Read(ctx)
 		is.NoErr(err)
 
+		is.Equal(readRec.Metadata[MetadataRabbitmqRoutingKey], routingKey)
 		is.Equal(readRec.Metadata[MetadataRabbitmqHeaderPrefix+"queue_name"], queueName)
 
 		var rec struct {
@@ -115,7 +123,38 @@ func testExchange(is *is.I, queueName, exchangeName, exchangeType, routingKey st
 
 func TestDestination_ExchangeWorks(t *testing.T) {
 	is := is.New(t)
-	testExchange(is, "testDirectQueue", "testDirectExchange", "direct", "specificRoutingKey")
-	testExchange(is, "testFanoutQueue", "testFanoutExchange", "fanout", "")
-	testExchange(is, "testTopicQueue", "testTopicExchange", "topic", "specificRoutingKey")
+	testExchange(is, "testDirectQueue", "testDirectExchange", "direct", "specificRoutingKey", "")
+	testExchange(is, "testFanoutQueue", "testFanoutExchange", "fanout", "testFanoutQueue", "")
+	testExchange(is, "testTopicQueue", "testTopicExchange", "topic", "specificRoutingKey", "")
+}
+
+func TestDestination_MetadataRoutingKeyWorks(t *testing.T) {
+	is := is.New(t)
+
+	exchangeName := "testTopicExchangeWithMetadataRoutingKey"
+	queueName := "testTopicQueueWithMetadataRoutingKey"
+	routingKey := "specificRoutingKey"
+
+	// Create queue to exchange binding
+	conn, err := amqp091.Dial(testURL)
+	is.NoErr(err)
+	ch, err := conn.Channel()
+	is.NoErr(err)
+
+	_, err = ch.QueueDeclare(queueName, true, false, false, false, nil)
+	is.NoErr(err)
+
+	err = ch.ExchangeDeclare(exchangeName, "topic", true, false, false, false, nil)
+	is.NoErr(err)
+	err = ch.QueueBind(queueName, routingKey, exchangeName, false, nil)
+	is.NoErr(err)
+	conn.Close()
+
+	testExchange(is,
+		queueName,
+		exchangeName,
+		"topic",
+		routingKey,
+		`{{ index .Metadata "rabbitmq.routingKey" }}`,
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/conduitio-labs/conduit-connector-rabbitmq
 go 1.24.2
 
 require (
+	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/conduitio/conduit-commons v0.5.2
 	github.com/conduitio/conduit-connector-sdk v0.13.3
-	github.com/google/uuid v1.6.0
 	github.com/matryer/is v1.4.1
 	github.com/rabbitmq/amqp091-go v1.10.0
 )
@@ -25,7 +25,6 @@ require (
 	github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.3.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1 // indirect
 	github.com/alecthomas/go-check-sumtype v0.3.1 // indirect
 	github.com/alexkohler/nakedret/v2 v2.0.5 // indirect
@@ -86,6 +85,7 @@ require (
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/unconvert v0.0.0-20240309020433-c5143eacb3ed // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gordonklaus/ineffassign v0.1.0 // indirect
 	github.com/gostaticanalysis/analysisutil v0.7.1 // indirect
 	github.com/gostaticanalysis/comment v1.5.0 // indirect

--- a/source_test.go
+++ b/source_test.go
@@ -98,7 +98,9 @@ func generateRabbitmqMsgs(from, to int) []amqp091.Publishing {
 			ContentType: "text/plain",
 			// setting testAppId asserts that the metadata is being set
 			AppId: testAppID,
-
+			Headers: amqp091.Table{
+				"app_id": testAppID,
+			},
 			Body: []byte(fmt.Sprintf("test-payload-%d", i)),
 		}
 
@@ -163,6 +165,7 @@ func testSourceIntegrationRead(
 
 		is.Equal(wantRecord.MessageId, string(rec.Key.Bytes()))
 		is.Equal(testAppID, rec.Metadata["rabbitmq.appId"])
+		is.Equal(testAppID, rec.Metadata[MetadataRabbitmqHeaderPrefix+"app_id"])
 
 		positions = append(positions, rec.Position)
 	}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   rabbitmq:
-    image: rabbitmq:3.12-management
+    image: rabbitmq:4.1-management
     container_name: rabbitmq
     ports:
       - "5671:5671" # tls

--- a/test/rabbitmq.conf
+++ b/test/rabbitmq.conf
@@ -13,3 +13,6 @@ ssl_options.fail_if_no_peer_cert	= true
 # For tls tests we just don't care about auth, as long as we can properly
 # connect
 loopback_users = none
+
+default_queue_type = quorum
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/utils.go
+++ b/utils.go
@@ -20,14 +20,16 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/conduitio/conduit-commons/opencdc"
 	sdk "github.com/conduitio/conduit-connector-sdk"
 	"github.com/rabbitmq/amqp091-go"
-	"os"
-	"strings"
 )
 
 const (
+	MetadataRabbitmqRoutingKey   = "rabbitmq.routingKey"
 	MetadataRabbitmqHeaderPrefix = "rabbitmq.header."
 )
 
@@ -96,7 +98,7 @@ func metadataFromMessage(msg amqp091.Delivery) opencdc.Metadata {
 	setKey("rabbitmq.deliveryTag", msg.DeliveryTag)
 	setKey("rabbitmq.redelivered", msg.Redelivered)
 	setKey("rabbitmq.exchange", msg.Exchange)
-	setKey("rabbitmq.routingKey", msg.RoutingKey)
+	setKey(MetadataRabbitmqRoutingKey, msg.RoutingKey)
 
 	for k, v := range msg.Headers {
 		// This will only set string values, ignoring everything else


### PR DESCRIPTION
### Description

This PR contains some chores and also improvements:

**(1) Bump docker image to rabbitmq 4.1 which is the current state of the art**

**(2) Implement metadata propagation to rabbitmq headers**
Record metadata keys prefixed with `rabbitmq.header.` are now propagated to AMQP 0.9 headers (and vice versa).

Fixes #67.

**(3) RoutingKey is now a golang template**

This is a breaking change. I don't know if it should be done this way, but this is very helpful and significantly improves the DX. The implementation is almost verbatim copied from kafka connector where destination topic is derived from metadata key as well.

Instead of creating a bunch of pipelines, it is now possible to use a single pipeline with a processor setting `rabbitmq.routingKey` (already existing metadata) to a desired value which then could be used as a topic exchange routing key.