### PR TITLE
Add settings for skipping queue and exchange declare call

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ pipelines:
           # Type: bool
           # Required: no
           queue.noWait: "false"
+          # Skips queue declare call assuming that it already exists.
+          # Type: bool
+          # Required: no
+          queue.skipDeclare: "false"
           # The path to the CA certificate to use for TLS
           # Type: string
           # Required: no
@@ -243,6 +247,10 @@ pipelines:
           # Type: bool
           # Required: no
           exchange.noWait: "false"
+          # Skips exchange declare call assuming that it already exists.
+          # Type: bool
+          # Required: no
+          exchange.skipDeclare: "false"
           # The type of the exchange (e.g., direct, fanout, topic, headers).
           # Type: string
           # Required: no
@@ -265,6 +273,10 @@ pipelines:
           # Type: bool
           # Required: no
           queue.noWait: "false"
+          # Skips queue declare call assuming that it already exists.
+          # Type: bool
+          # Required: no
+          queue.skipDeclare: "false"
           # The routing key to use when publishing to an exchange
           # Type: string
           # Required: no

--- a/config.go
+++ b/config.go
@@ -57,6 +57,9 @@ type QueueConfig struct {
 	// The name of the queue to consume from / publish to
 	Name string `json:"name" validate:"required"`
 
+	// Skips queue declare call assuming that it already exists.
+	SkipDeclare bool `json:"skipDeclare" default:"false"`
+
 	// Indicates if the queue will survive broker restarts.
 	Durable bool `json:"durable" default:"true"`
 
@@ -101,6 +104,9 @@ type ExchangeConfig struct {
 
 	// The type of the exchange (e.g., direct, fanout, topic, headers).
 	Type string `json:"type"`
+
+	// Skips exchange declare call assuming that it already exists.
+	SkipDeclare bool `json:"skipDeclare" default:"false"`
 
 	// Indicates if the exchange will survive broker restarts.
 	Durable bool `json:"durable" default:"true"`

--- a/connector.yaml
+++ b/connector.yaml
@@ -66,6 +66,11 @@ specification:
         type: bool
         default: "false"
         validations: []
+      - name: queue.skipDeclare
+        description: Skips queue declare call assuming that it already exists.
+        type: bool
+        default: "false"
+        validations: []
       - name: tls.caCert
         description: The path to the CA certificate to use for TLS
         type: string
@@ -251,6 +256,11 @@ specification:
         type: bool
         default: "false"
         validations: []
+      - name: exchange.skipDeclare
+        description: Skips exchange declare call assuming that it already exists.
+        type: bool
+        default: "false"
+        validations: []
       - name: exchange.type
         description: The type of the exchange (e.g., direct, fanout, topic, headers).
         type: string
@@ -273,6 +283,11 @@ specification:
         validations: []
       - name: queue.noWait
         description: Indicates if the queue should be declared without waiting for server confirmation.
+        type: bool
+        default: "false"
+        validations: []
+      - name: queue.skipDeclare
+        description: Skips queue declare call assuming that it already exists.
         type: bool
         default: "false"
         validations: []


### PR DESCRIPTION
### Description

This is the last change that would allow me to fully switch to the upstream connector.
Sometimes, rabbitmq broker settings can be complex or bad. E.g: my existing queue has `x-queue-type: quorum`, but there could be no default queue type specified globally on the broker. In that case, declaring queue from the connector will fail because conduit is not sending any args. If the queue already exists, declare call must be identical.

I find it tedious to keep track of the settings and just want to use my existing queues and exchanges with their own pre-existing bindings without touching anything.

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-rabbitmq/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
